### PR TITLE
Implement Solicitudes CRUD

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -1,12 +1,14 @@
 import express from 'express';
 import metahumanoRoutes from './routes/meta.routes.js';
-import  poderRoutes  from './routes/poder.routes.js';
+import poderRoutes from './routes/poder.routes.js';
+import solicitudesRoutes from './routes/solicitudes.routes.js';
 
 const app = express();
 app.use(express.json());
 
 app.use("/metahumanos", metahumanoRoutes);
 app.use("/poderes", poderRoutes);
+app.use("/solicitudes", solicitudesRoutes);
 
 app.get("/", (req, res) => res.send("Hello World"));
 

--- a/src/controller/solicitud.controller.ts
+++ b/src/controller/solicitud.controller.ts
@@ -1,0 +1,69 @@
+import { Request, Response } from "express";
+import { Solicitud } from "../models/solicitudes.model.js";
+
+const solicitudes: Solicitud[] = [];
+
+// Obtener todas las solicitudes
+export const getSolicitudes = (req: Request, res: Response) => {
+  res.json({ data: solicitudes });
+};
+
+// Obtener una solicitud por id
+export const getSolicitud = (req: Request, res: Response) => {
+  const id = req.params.id;
+  const solicitud = solicitudes.find((s) => s.id_solicitud === id);
+  if (!solicitud) {
+    return res.status(404).json({ error: "No encontrado" });
+  }
+  res.json({ data: solicitud });
+};
+
+// Crear una solicitud
+export const createSolicitud = (req: Request, res: Response) => {
+  const nuevo = new Solicitud(
+    undefined,
+    req.body.id_meta,
+    req.body.id_poder,
+    req.body.fecha_solicitud ? new Date(req.body.fecha_solicitud) : new Date(),
+    req.body.estado,
+    req.body.descripcion
+  );
+  solicitudes.push(nuevo);
+
+  res.status(201).json({ message: "Solicitud creada", data: nuevo });
+};
+
+// Actualizar una solicitud
+export const updateSolicitud = (req: Request, res: Response) => {
+  const id = req.params.id;
+  const index = solicitudes.findIndex((s) => s.id_solicitud === id);
+  if (index === -1) {
+    return res.status(404).json({ error: "No encontrado" });
+  }
+
+  solicitudes[index] = {
+    ...solicitudes[index],
+    id_meta: req.body.id_meta ?? solicitudes[index].id_meta,
+    id_poder: req.body.id_poder ?? solicitudes[index].id_poder,
+    fecha_solicitud: req.body.fecha_solicitud
+      ? new Date(req.body.fecha_solicitud)
+      : solicitudes[index].fecha_solicitud,
+    estado: req.body.estado ?? solicitudes[index].estado,
+    descripcion: req.body.descripcion ?? solicitudes[index].descripcion,
+  };
+
+  res.json({ message: `Solicitud ${id} actualizada`, data: solicitudes[index] });
+};
+
+// Eliminar una solicitud
+export const deleteSolicitud = (req: Request, res: Response) => {
+  const id = req.params.id;
+  const index = solicitudes.findIndex((s) => s.id_solicitud === id);
+  if (index === -1) {
+    return res.status(404).json({ error: "No encontrado" });
+  }
+
+  solicitudes.splice(index, 1);
+  res.json({ message: `Solicitud ${id} eliminada` });
+};
+

--- a/src/routes/solicitudes.routes.ts
+++ b/src/routes/solicitudes.routes.ts
@@ -1,8 +1,18 @@
 import { Router } from "express";
-const router = Router();
 import {
-    getSolicitudes,
-    getSolicitud,
-    createSolicitud,
-    updateSolicitud
-} from "./controller/solicitud.controller.ts";
+  getSolicitudes,
+  getSolicitud,
+  createSolicitud,
+  updateSolicitud,
+  deleteSolicitud,
+} from "../controller/solicitud.controller.js";
+
+const router = Router();
+
+router.get("/", getSolicitudes);
+router.get("/:id", getSolicitud);
+router.post("/", createSolicitud);
+router.put("/:id", updateSolicitud);
+router.delete("/:id", deleteSolicitud);
+
+export default router;


### PR DESCRIPTION
## Summary
- add controller for Solicitudes
- expose routes for Solicitudes
- wire Solicitudes routes in app

## Testing
- `npx tsc`
- `node dist/app.js` *(started server)*

------
https://chatgpt.com/codex/tasks/task_e_684d8d6725188323a69bbafdb58218ba