### PR TITLE
Refactor powers CRUD with service layer

### DIFF
--- a/src/controller/poder.controller.ts
+++ b/src/controller/poder.controller.ts
@@ -1,70 +1,43 @@
 import { Request, Response } from "express";
-import { Poder } from "../models/poder.model.js";
+import { PoderService } from "../services/poder.service.js";
+import { InMemoryPoderRepository } from "../repositories/poder.repository.js";
 
-const poderes: Poder[] = [];
-//Obtener todos los poderes
+const service = new PoderService(new InMemoryPoderRepository());
+
 export const getPoderes = (req: Request, res: Response) => {
-    res.json({ data: poderes });
-}
-//Obtener un poder por id
+  res.json({ data: service.getAll() });
+};
+
 export const getPoder = (req: Request, res: Response) => {
-    const id = req.params.id;
-    const poder = poderes.find(p => p.id_Poder === id);
-    if (!poder) {
-        return res.status(404).json({ error: "No encontrado" });
-    }
-    res.json({ data: poder });
-}
-//Crear un poder
+  const poder = service.getById(req.params.id);
+  if (!poder) {
+    return res.status(404).json({ error: "No encontrado" });
+  }
+  res.json({ data: poder });
+};
+
 export const createPoder = (req: Request, res: Response) => {
-    console.log('BODY RECIBIDO:', req.body);
-    
-    // Validación
-    if (!req.body.nom_poder || !req.body.debilidad) {
-        return res.status(400).json({ error: "nom_poder y debilidad son requeridos" });
-    }
-    // Instancia nueva
-    const nuevo = new Poder(
-        undefined,
-        req.body.nom_poder,
-        req.body.debilidad,
-        req.body.desc_poder,
-        req.body.desc_debilidad,
-        req.body.categoria,
-        req.body.costoMulta
-    );
-    poderes.push(nuevo);
-
+  try {
+    const nuevo = service.create(req.body);
     res.status(201).json({ message: "Poder creado", data: nuevo });
-}
-// Actualizar un poder
-export const updatePoder = (req: Request, res: Response) => {
-    const id = req.params.id;
-    const index = poderes.findIndex(p => p.id_Poder === id);
-    if (index === -1) {
-        return res.status(404).json({ error: "No encontrado" });
-    }
-    
-    // Actualiza los campos del poder
-    poderes[index].nom_poder = req.body.nom_poder ?? poderes[index].nom_poder;
-    poderes[index].debilidad = req.body.debilidad ?? poderes[index].debilidad;
-    poderes[index].desc_poder = req.body.desc_poder ?? poderes[index].desc_poder;
-    poderes[index].desc_debilidad = req.body.desc_debilidad ?? poderes[index].desc_debilidad;
-    poderes[index].categoria = req.body.categoria ?? poderes[index].categoria;
-    poderes[index].costoMulta = req.body.costoMulta ?? poderes[index].costoMulta;
+  } catch (err: any) {
+    res.status(400).json({ error: err.message });
+  }
+};
 
-    res.json({ message: "Poder actualizado", data: poderes[index] });
-}
-// Eliminar un poder
-export const deletePoder = (req: Request, res: Response) => {
-    const id = req.params.id;
-    const index = poderes.findIndex(p => p.id_Poder === id);
-    if (index === -1) {
-        return res.status(404).json({ error: "No encontrado" });
+export const updatePoder = (req: Request, res: Response) => {
+  try {
+    const actualizado = service.update(req.params.id, req.body);
+    res.json({ message: "Poder actualizado", data: actualizado });
+  } catch (err: any) {
+    if (err.message === "No encontrado") {
+      return res.status(404).json({ error: err.message });
     }
-    
-    // Elimina el poder
-    poderes.splice(index, 1);
-    
-    res.json({ message: "Poder eliminado" });
-}
+    res.status(400).json({ error: err.message });
+  }
+};
+
+export const deletePoder = (req: Request, res: Response) => {
+  service.delete(req.params.id);
+  res.json({ message: "Poder eliminado" });
+};

--- a/src/repositories/poder.repository.ts
+++ b/src/repositories/poder.repository.ts
@@ -1,0 +1,39 @@
+import { Poder } from "../models/poder.model.js";
+
+export interface IPoderRepository {
+  getAll(): Poder[];
+  getById(id: string): Poder | undefined;
+  create(poder: Poder): void;
+  update(poder: Poder): void;
+  delete(id: string): void;
+}
+
+export class InMemoryPoderRepository implements IPoderRepository {
+  private poderes: Poder[] = [];
+
+  getAll(): Poder[] {
+    return this.poderes;
+  }
+
+  getById(id: string): Poder | undefined {
+    return this.poderes.find(p => p.id_Poder === id);
+  }
+
+  create(poder: Poder): void {
+    this.poderes.push(poder);
+  }
+
+  update(poder: Poder): void {
+    const index = this.poderes.findIndex(p => p.id_Poder === poder.id_Poder);
+    if (index !== -1) {
+      this.poderes[index] = poder;
+    }
+  }
+
+  delete(id: string): void {
+    const index = this.poderes.findIndex(p => p.id_Poder === id);
+    if (index !== -1) {
+      this.poderes.splice(index, 1);
+    }
+  }
+}

--- a/src/services/poder.service.ts
+++ b/src/services/poder.service.ts
@@ -1,0 +1,62 @@
+import { Poder } from "../models/poder.model.js";
+import { IPoderRepository } from "../repositories/poder.repository.js";
+
+export interface PoderCreateDto {
+  nom_poder: string;
+  debilidad: string;
+  desc_poder?: string;
+  desc_debilidad?: string;
+  categoria?: string;
+  costoMulta?: number;
+}
+
+export class PoderService {
+  constructor(private repository: IPoderRepository) {}
+
+  getAll(): Poder[] {
+    return this.repository.getAll();
+  }
+
+  getById(id: string): Poder | undefined {
+    return this.repository.getById(id);
+  }
+
+  create(data: PoderCreateDto): Poder {
+    if (!data.nom_poder || !data.debilidad) {
+      throw new Error("nom_poder y debilidad son requeridos");
+    }
+    const poder = new Poder(
+      undefined,
+      data.nom_poder,
+      data.debilidad,
+      data.desc_poder ?? "",
+      data.desc_debilidad ?? "",
+      data.categoria ?? "",
+      data.costoMulta ?? 0
+    );
+    this.repository.create(poder);
+    return poder;
+  }
+
+  update(id: string, data: Partial<PoderCreateDto>): Poder {
+    const existing = this.repository.getById(id);
+    if (!existing) {
+      throw new Error("No encontrado");
+    }
+    const updated = new Poder(
+      existing.id_Poder,
+      data.nom_poder ?? existing.nom_poder,
+      data.debilidad ?? existing.debilidad,
+      data.desc_poder ?? existing.desc_poder,
+      data.desc_debilidad ?? existing.desc_debilidad,
+      data.categoria ?? existing.categoria,
+      data.costoMulta ?? existing.costoMulta
+    );
+    this.repository.update(updated);
+    return updated;
+  }
+
+  delete(id: string): void {
+    this.repository.delete(id);
+  }
+}


### PR DESCRIPTION
## Summary
- apply SOLID principles to powers controller
- add `InMemoryPoderRepository` and `PoderService`
- refactor controller to use service

## Testing
- `npm install`
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_686c20f69240832389b7915a875de4e2